### PR TITLE
Pp refresh

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -32,10 +32,7 @@ impl<'de, 'a> serde::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        let caps = self
-            .regex
-            .captures(&self.input)
-            .ok_or_else(Error::NoMatch)?;
+        let caps = self.regex.captures(self.input).ok_or_else(Error::NoMatch)?;
 
         let items = self.regex.capture_names().filter_map(|n| {
             n.and_then(|name| {

--- a/src/de.rs
+++ b/src/de.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 
 use crate::error::*;
 
-pub(crate) struct Deserializer<'de> {
+pub struct Deserializer<'de> {
     input: &'de str,
     regex: Regex,
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -18,7 +18,7 @@ impl<'de> Deserializer<'de> {
     }
 }
 
-impl<'de, 'a> serde::Deserializer<'de> for &'a mut Deserializer<'de> {
+impl<'de> serde::Deserializer<'de> for &'_ mut Deserializer<'de> {
     type Error = Error;
 
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>

--- a/src/de.rs
+++ b/src/de.rs
@@ -70,6 +70,7 @@ struct Value {
 }
 
 impl Value {
+    #[allow(clippy::map_err_ignore)]
     fn parse<T>(&self) -> Result<T>
     where
         T: FromStr,

--- a/src/de.rs
+++ b/src/de.rs
@@ -21,6 +21,7 @@ impl<'de> Deserializer<'de> {
 impl<'de> serde::Deserializer<'de> for &'_ mut Deserializer<'de> {
     type Error = Error;
 
+    #[inline]
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
-use serde::de::{Visitor, IntoDeserializer};
 use serde::de::value::MapDeserializer;
+use serde::de::{IntoDeserializer, Visitor};
 
 use regex::Regex;
 
@@ -14,27 +14,41 @@ pub(crate) struct Deserializer<'de> {
 
 impl<'de> Deserializer<'de> {
     pub fn new(input: &'de str, regex: Regex) -> Deserializer {
-        Deserializer {
-            input,
-            regex,
-        }
+        Deserializer { input, regex }
     }
 }
 
 impl<'de, 'a> serde::Deserializer<'de> for &'a mut Deserializer<'de> {
     type Error = Error;
 
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value> where V: Visitor<'de> {
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
         self.deserialize_map(visitor)
     }
 
-    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value> where V: Visitor<'de> {
-        let caps = self.regex.captures(&self.input).ok_or_else(Error::NoMatch)?;
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        let caps = self
+            .regex
+            .captures(&self.input)
+            .ok_or_else(Error::NoMatch)?;
 
         let items = self.regex.capture_names().filter_map(|n| {
-            n.and_then(|name| caps.name(name).map(|value| {
-                (name.to_owned(), Value { name: name.to_owned(), value: value.as_str().to_owned() })
-            }))
+            n.and_then(|name| {
+                caps.name(name).map(|value| {
+                    (
+                        name.to_owned(),
+                        Value {
+                            name: name.to_owned(),
+                            value: value.as_str().to_owned(),
+                        },
+                    )
+                })
+            })
         });
 
         let ms = MapDeserializer::new(items);
@@ -53,14 +67,16 @@ impl<'de, 'a> serde::Deserializer<'de> for &'a mut Deserializer<'de> {
     }
 }
 
-
 struct Value {
     name: String,
     value: String,
 }
 
 impl Value {
-    fn parse<T>(&self) -> Result<T> where T: FromStr {
+    fn parse<T>(&self) -> Result<T>
+    where
+        T: FromStr,
+    {
         self.value.parse().map_err(|_| self.get_parse_error())
     }
 
@@ -83,11 +99,17 @@ impl<'de> IntoDeserializer<'de, Error> for Value {
 impl<'de> serde::Deserializer<'de> for Value {
     type Error = Error;
 
-    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value> where V: Visitor<'de> {
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
         self.value.into_deserializer().deserialize_any(visitor)
     }
 
-    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value> where V: Visitor<'de> {
+    fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
         if self.value.eq_ignore_ascii_case("true") {
             visitor.visit_bool(true)
         } else if self.value.eq_ignore_ascii_case("false") {
@@ -97,47 +119,80 @@ impl<'de> serde::Deserializer<'de> for Value {
         }
     }
 
-    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value> where V: Visitor<'de> {
+    fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
         visitor.visit_i8(self.parse()?)
     }
 
-    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value> where V: Visitor<'de> {
+    fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
         visitor.visit_i16(self.parse()?)
     }
 
-    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value> where V: Visitor<'de> {
+    fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
         visitor.visit_i32(self.parse()?)
     }
 
-    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value> where V: Visitor<'de> {
+    fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
         visitor.visit_i64(self.parse()?)
     }
 
-    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value> where V: Visitor<'de> {
+    fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
         visitor.visit_u8(self.parse()?)
     }
 
-    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value> where V: Visitor<'de> {
+    fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
         visitor.visit_u16(self.parse()?)
     }
 
-    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value> where V: Visitor<'de> {
+    fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
         visitor.visit_u32(self.parse()?)
     }
 
-    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value> where V: Visitor<'de> {
+    fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
         visitor.visit_u64(self.parse()?)
     }
 
-    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value> where V: Visitor<'de> {
+    fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
         visitor.visit_f32(self.parse()?)
     }
 
-    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value> where V: Visitor<'de> {
+    fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
         visitor.visit_f64(self.parse()?)
     }
 
-    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value> where V: Visitor<'de> {
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
         if self.value.is_empty() {
             visitor.visit_none()
         } else {
@@ -145,11 +200,22 @@ impl<'de> serde::Deserializer<'de> for Value {
         }
     }
 
-    fn deserialize_newtype_struct<V>(self, _: &'static str, visitor: V) -> Result<V::Value> where V: Visitor<'de> {
+    fn deserialize_newtype_struct<V>(self, _: &'static str, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
         visitor.visit_newtype_struct(self)
     }
 
-    fn deserialize_enum<V>(self, _name: &'static str, _variants: &'static [&'static str], visitor: V) -> Result<V::Value> where V: Visitor<'de> {
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
         visitor.visit_enum(self.value.into_deserializer())
     }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -13,7 +13,7 @@ pub struct Deserializer<'de> {
 }
 
 impl<'de> Deserializer<'de> {
-    pub fn new(input: &'de str, regex: Regex) -> Deserializer {
+    pub const fn new(input: &'de str, regex: Regex) -> Deserializer {
         Deserializer { input, regex }
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -32,10 +32,9 @@ impl<'de, 'a> serde::Deserializer<'de> for &'a mut Deserializer<'de> {
         let caps = self.regex.captures(&self.input).ok_or_else(Error::NoMatch)?;
 
         let items = self.regex.capture_names().filter_map(|n| {
-            n.map(|name| {
-                let value = &caps[name];
-                (name.to_owned(), Value { name: name.to_owned(), value: value.to_owned() })
-            })
+            n.and_then(|name| caps.name(name).map(|value| {
+                (name.to_owned(), Value { name: name.to_owned(), value: value.as_str().to_owned() })
+            }))
         });
 
         let ms = MapDeserializer::new(items);

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use std::fmt::{Display, Formatter};
 
 /// An error that occurred during deserialization.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// An error occurred while parsing the regular expression
     BadRegex(regex::Error),

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,7 @@ pub enum Error {
 }
 
 impl serde::de::Error for Error {
+    #[inline]
     fn custom<T>(msg: T) -> Self
     where
         T: Display,
@@ -35,6 +36,7 @@ impl serde::de::Error for Error {
 impl std::error::Error for Error {}
 
 impl Display for Error {
+    #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use Error::*;
         match *self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,13 +36,16 @@ impl std::error::Error for Error {}
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use Error::*;
-        match self {
-            BadRegex(err) => err.fmt(f),
+        match *self {
+            BadRegex(ref err) => err.fmt(f),
             NoMatch() => write!(f, "String doesn't match pattern"),
-            BadValue { name, value } => {
+            BadValue {
+                ref name,
+                ref value,
+            } => {
                 write!(f, "Unable to convert value for group {}: {}", name, value)
             }
-            Custom(err) => write!(f, "{}", err),
+            Custom(ref err) => write!(f, "{}", err),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,4 +53,4 @@ impl Display for Error {
 
 // Do not use this alias in public parts of the crate because
 // it would hide the direct link to the actual error type in rustdoc.
-pub(crate) type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,10 @@ pub enum Error {
 }
 
 impl serde::de::Error for Error {
-    fn custom<T>(msg: T) -> Self where T: Display {
+    fn custom<T>(msg: T) -> Self
+    where
+        T: Display,
+    {
         Self::Custom(msg.to_string())
     }
 }
@@ -36,7 +39,9 @@ impl Display for Error {
         match self {
             BadRegex(err) => err.fmt(f),
             NoMatch() => write!(f, "String doesn't match pattern"),
-            BadValue { name, value } => write!(f, "Unable to convert value for group {}: {}", name, value),
+            BadValue { name, value } => {
+                write!(f, "Unable to convert value for group {}: {}", name, value)
+            }
             Custom(err) => write!(f, "{}", err),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,6 +274,24 @@ mod test {
     }
 
     #[test]
+    fn test_option_present() {
+        let regex = r"^(?P<foo>\d*)(?:,(?P<bar>-?\d*))?$";
+        let input = "1,-2";
+        let output: Test3 = from_str(input, regex).unwrap();
+
+        assert_eq!(output, Test3 { foo: Some(1), bar: Some(-2) });
+    }
+
+    #[test]
+    fn test_option_missing() {
+        let regex = r"^(?P<foo>\d*)(?:,(?P<bar>-?\d*))?$";
+        let input = "1";
+        let output: Test3 = from_str(input, regex).unwrap();
+
+        assert_eq!(output, Test3 { foo: Some(1), bar: None });
+    }
+
+    #[test]
     fn test_bool() {
         #[derive(Deserialize)]
         struct TestBool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ use serde::Deserialize;
 /// # Ok(())
 /// # }
 /// ```
+#[inline]
 pub fn from_str<'input, T>(input: &'input str, regex: &str) -> std::result::Result<T, Error>
 where
     T: Deserialize<'input>,
@@ -152,6 +153,7 @@ where
 /// # Ok(())
 /// # }
 /// ```
+#[inline]
 pub fn from_str_regex<'input, T>(input: &'input str, regex: Regex) -> std::result::Result<T, Error>
 where
     T: Deserialize<'input>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,8 +124,8 @@ pub fn from_str<'input, T>(input: &'input str, regex: &str) -> std::result::Resu
 where
     T: Deserialize<'input>,
 {
-    let regex = Regex::new(regex).map_err(Error::BadRegex)?;
-    from_str_regex(input, regex)
+    let rex = Regex::new(regex).map_err(Error::BadRegex)?;
+    from_str_regex(input, rex)
 }
 
 /// Deserialize an input string into a struct.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,13 +89,13 @@ If your regular expression looks like a behemoth no mere mortal will ever unders
  *
  */
 
-mod error;
 mod de;
+mod error;
 
 pub use error::Error;
 
-use serde::Deserialize;
 use regex::Regex;
+use serde::Deserialize;
 
 /// Deserialize an input string into a struct.
 ///
@@ -120,7 +120,10 @@ use regex::Regex;
 /// # Ok(())
 /// # }
 /// ```
-pub fn from_str<'a, T>(input: &'a str, regex: &str) -> std::result::Result<T, Error> where T: Deserialize<'a> {
+pub fn from_str<'a, T>(input: &'a str, regex: &str) -> std::result::Result<T, Error>
+where
+    T: Deserialize<'a>,
+{
     let regex = Regex::new(&regex).map_err(Error::BadRegex)?;
     from_str_regex(input, regex)
 }
@@ -149,15 +152,18 @@ pub fn from_str<'a, T>(input: &'a str, regex: &str) -> std::result::Result<T, Er
 /// # Ok(())
 /// # }
 /// ```
-pub fn from_str_regex<'a, T>(input: &'a str, regex: Regex) -> std::result::Result<T, Error> where T: Deserialize<'a> {
+pub fn from_str_regex<'a, T>(input: &'a str, regex: Regex) -> std::result::Result<T, Error>
+where
+    T: Deserialize<'a>,
+{
     let mut deserializer = de::Deserializer::new(input, regex);
     T::deserialize(&mut deserializer)
 }
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use super::error::Result;
+    use super::*;
 
     #[derive(Deserialize, PartialEq, Debug)]
     struct Test {
@@ -233,20 +239,23 @@ mod test {
         let input = "true,1,2,3,4,-1,-2,-3,-4,1.0,-1.0,foobar";
         let output: Test2 = from_str(input, TEST2_PATTERN).unwrap();
 
-        assert_eq!(output, Test2 {
-            f_bool: true,
-            f_u8: 1,
-            f_u16: 2,
-            f_u32: 3,
-            f_u64: 4,
-            f_i8: -1,
-            f_i16: -2,
-            f_i32: -3,
-            f_i64: -4,
-            f_f32: 1.0,
-            f_f64: -1.0,
-            f_str: "foobar".to_owned(),
-        });
+        assert_eq!(
+            output,
+            Test2 {
+                f_bool: true,
+                f_u8: 1,
+                f_u16: 2,
+                f_u32: 3,
+                f_u64: 4,
+                f_i8: -1,
+                f_i16: -2,
+                f_i32: -3,
+                f_i64: -4,
+                f_f32: 1.0,
+                f_f64: -1.0,
+                f_str: "foobar".to_owned(),
+            }
+        );
     }
 
     #[derive(Deserialize, PartialEq, Debug)]
@@ -261,7 +270,13 @@ mod test {
         let input = "1,-2";
         let output: Test3 = from_str(input, regex).unwrap();
 
-        assert_eq!(output, Test3 { foo: Some(1), bar: Some(-2) });
+        assert_eq!(
+            output,
+            Test3 {
+                foo: Some(1),
+                bar: Some(-2)
+            }
+        );
     }
 
     #[test]
@@ -270,7 +285,13 @@ mod test {
         let input = ",";
         let output: Test3 = from_str(input, regex).unwrap();
 
-        assert_eq!(output, Test3 { foo: None, bar: None });
+        assert_eq!(
+            output,
+            Test3 {
+                foo: None,
+                bar: None
+            }
+        );
     }
 
     #[test]
@@ -279,7 +300,13 @@ mod test {
         let input = "1,-2";
         let output: Test3 = from_str(input, regex).unwrap();
 
-        assert_eq!(output, Test3 { foo: Some(1), bar: Some(-2) });
+        assert_eq!(
+            output,
+            Test3 {
+                foo: Some(1),
+                bar: Some(-2)
+            }
+        );
     }
 
     #[test]
@@ -288,7 +315,13 @@ mod test {
         let input = "1";
         let output: Test3 = from_str(input, regex).unwrap();
 
-        assert_eq!(output, Test3 { foo: Some(1), bar: None });
+        assert_eq!(
+            output,
+            Test3 {
+                foo: Some(1),
+                bar: None
+            }
+        );
     }
 
     #[test]
@@ -365,7 +398,11 @@ mod test {
         let input = "aaa1,-2";
         let output: Result<Test> = from_str(input, regex);
 
-        assert!(matches!(output, Err(Error::BadValue{..})), "Expected Error::BadValue got {:?}", output);
+        assert!(
+            matches!(output, Err(Error::BadValue { .. })),
+            "Expected Error::BadValue got {:?}",
+            output
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ pub fn from_str<'a, T>(input: &'a str, regex: &str) -> std::result::Result<T, Er
 where
     T: Deserialize<'a>,
 {
-    let regex = Regex::new(&regex).map_err(Error::BadRegex)?;
+    let regex = Regex::new(regex).map_err(Error::BadRegex)?;
     from_str_regex(input, regex)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,9 +120,9 @@ use serde::Deserialize;
 /// # Ok(())
 /// # }
 /// ```
-pub fn from_str<'a, T>(input: &'a str, regex: &str) -> std::result::Result<T, Error>
+pub fn from_str<'input, T>(input: &'input str, regex: &str) -> std::result::Result<T, Error>
 where
-    T: Deserialize<'a>,
+    T: Deserialize<'input>,
 {
     let regex = Regex::new(regex).map_err(Error::BadRegex)?;
     from_str_regex(input, regex)
@@ -152,9 +152,9 @@ where
 /// # Ok(())
 /// # }
 /// ```
-pub fn from_str_regex<'a, T>(input: &'a str, regex: Regex) -> std::result::Result<T, Error>
+pub fn from_str_regex<'input, T>(input: &'input str, regex: Regex) -> std::result::Result<T, Error>
 where
-    T: Deserialize<'a>,
+    T: Deserialize<'input>,
 {
     let mut deserializer = de::Deserializer::new(input, regex);
     T::deserialize(&mut deserializer)


### PR DESCRIPTION
Hi,

What do you think about the attached (mostly trivial) commits that address some style issues reported by `cargo fmt` and `cargo clippy` with a couple of non-default Clippy categories allowed? (most of the clippy::restriction ones, some clippy::pedantic ones, and clippy::nursery) Of course, as the author of the de-regex crate the decision as to which of these make sense and which are just busy-work lies entirely with you :)

Thanks again, and keep up the great work!

G'luck,
Peter
